### PR TITLE
Fixed typo in navigation bar settings

### DIFF
--- a/res/values/slim_strings.xml
+++ b/res/values/slim_strings.xml
@@ -599,7 +599,7 @@ two in order to insert additional control points. \'Remove\' deletes the selecte
     <string name="navigation_bar_width_title">Navigation bar width</string>
     <string name="navigation_bar_width_summary">Navigation bar height if the bar is along a side.</string>
     <string name="navbar_can_move">Show landscape</string>
-    <string name="navbar_can_move_summary">Shows navigation bar in lanscape on the bottom</string>
+    <string name="navbar_can_move_summary">Shows navigation bar in landscape on the bottom</string>
     <string name="navbar_style_dimen_title">Dimensions</string>
     <string name="navbar_button_title">Buttons</string>
     <string name="navbar_targets_title">Ring targets</string>


### PR DESCRIPTION
Fixed a small typo in `slim_strings.xml` (visible in Navigation bar settings)
